### PR TITLE
改善评论处理逻辑

### DIFF
--- a/components/Comment/box.tsx
+++ b/components/Comment/box.tsx
@@ -32,7 +32,7 @@ const CommentBox: FC<{
     onCancel?.()
     reset()
   }
-  const handleSubmit = () => {
+  const handleSubmit = async () => {
     if (!logged) {
       if (author === userStore.name || author === userStore.username) {
         return message.error('昵称与我主人重名了, 但是你好像并不是我的主人唉')
@@ -65,8 +65,8 @@ const CommentBox: FC<{
       mail: mail,
       url: url || undefined,
     }
-    onSubmit(model)
     localStorage.setItem(USER_PREFIX, JSON.stringify(omit(model, ['text'])))
+    await onSubmit(model)
     reset()
   }
   useEffect(() => {


### PR DESCRIPTION
评论提交失败将不再清空表单。因为是个小问题，所以没拖下来盲改的。用了 `await` 的话，提交失败应该不会执行后面的 `reset` 了。
~~忘记用英文提交了，抱歉。另外这个问题是我连续提交几次评论发现的，服务器总傲娇呢~~